### PR TITLE
Add name change pricing and billing functionality to config and server scripts.

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -6,7 +6,7 @@
 --		\_|  |_/|_|   \_| \_/ \___|  \_/\_/  |_.__/ \____/  \___||_|   |_|| .__/  \__||___/		
 --                                                                  | |              			
 --                                                                  |_|              			
---		  Need support? Join our Discord server for help: https://discord.gg/d3Kh2vz3a7		
+--		  Need support? Join our Discord server for help: https://discord.gg/mrnewbscripts		
 
 Config = {
 	ox_lib = true,										-- set this to true if using ox_lib, if false comment it out in the manifest
@@ -22,7 +22,11 @@ Config = {
 	filledcertificate = "filledcertificate",       		-- set this to item for a filled certificate to apply on use (by a judge or something)
 	joblock = true,             						-- set this to true to prevent any job from randomly creating these, I can't imagine the chaos that would come otherwise
 	jobname = "police",           						-- set this to a desired job name that can use this item, to use this Config.joblock must be set to true
-	
+	paymentType = "none",         						-- set this to the payment type, can be "item", "cash", "bank", or "none"
+	namechangeprice = 1000,        						-- set this to the price of the name change
+	currencyItem = "cash",         						-- set this to the item name if paymentType is set to "item"
+
+
 	-- Language Configuration
 
 	lang = {

--- a/config.lua
+++ b/config.lua
@@ -22,9 +22,8 @@ Config = {
 	filledcertificate = "filledcertificate",       		-- set this to item for a filled certificate to apply on use (by a judge or something)
 	joblock = true,             						-- set this to true to prevent any job from randomly creating these, I can't imagine the chaos that would come otherwise
 	jobname = "police",           						-- set this to a desired job name that can use this item, to use this Config.joblock must be set to true
-	paymentType = "none",         						-- set this to the payment type, can be "item", "cash", "bank", or "none"
+	paymentType = "none",         						-- set this to the payment type, can be "cash", "bank", or "none"
 	namechangeprice = 1000,        						-- set this to the price of the name change
-	currencyItem = "cash",         						-- set this to the item name if paymentType is set to "item"
 
 
 	-- Language Configuration

--- a/server/server.lua
+++ b/server/server.lua
@@ -57,9 +57,7 @@ end
 
 local function canBillPlayer(src)
 	local price = Config.namechangeprice
-	if Config.paymentType == "item" then
-		return (exports.ox_inventory:search(src, 'count', Config.currencyItem) >= price)
-	elseif Config.paymentType == "cash" then
+	if Config.paymentType == "cash" then
 		return Player.Functions.GetMoney('cash') >= price
 	elseif Config.paymentType == "bank" then
 		return Player.Functions.GetMoney('bank') >= price
@@ -72,9 +70,7 @@ local function billPlayer(src)
 
 	if not Player then return end
 
-	if Config.paymentType == "item" then
-		exports.ox_inventory:RemoveItem(src, Config.currencyItem, price)
-	elseif Config.paymentType == "cash" then
+	if Config.paymentType == "cash" then
 		Player.Functions.RemoveMoney('cash', price)
 	elseif Config.paymentType == "bank" then
 		Player.Functions.RemoveMoney('bank', price)


### PR DESCRIPTION
This pull request introduces several changes to the `config.lua` and `server/server.lua` files to add new configuration options and functionalities related to payment types for name changes. The most important changes include updating the Discord server link, adding new configuration options for payment types, and implementing billing functions.

Configuration updates:

* [`config.lua`](diffhunk://#diff-437dcbdcefbb257379ec6d95c6877f5f4feb823b3c5d920b643f9aeebcad7db0L9-R9): Updated the Discord server link to "https://discord.gg/mrnewbscripts".
* [`config.lua`](diffhunk://#diff-437dcbdcefbb257379ec6d95c6877f5f4feb823b3c5d920b643f9aeebcad7db0R25-R28): Added new configuration options `paymentType`, `namechangeprice`, and `currencyItem` to support different payment methods for name changes.

Billing functionality:

* [`server/server.lua`](diffhunk://#diff-1ef5404ab5f67fd7344b30877b71426d00bb7b78727ba4d648445f66bc54569fR56-R83): Added `canBillPlayer` function to check if a player can afford the name change based on the configured payment type.
* [`server/server.lua`](diffhunk://#diff-1ef5404ab5f67fd7344b30877b71426d00bb7b78727ba4d648445f66bc54569fR56-R83): Added `billPlayer` function to deduct the appropriate amount from the player based on the configured payment type.
* [`server/server.lua`](diffhunk://#diff-1ef5404ab5f67fd7344b30877b71426d00bb7b78727ba4d648445f66bc54569fR102-R105): Modified the `MrNewbNameChanger:change` event to include billing logic, ensuring the player is billed correctly before changing the name. [[1]](diffhunk://#diff-1ef5404ab5f67fd7344b30877b71426d00bb7b78727ba4d648445f66bc54569fR102-R105) [[2]](diffhunk://#diff-1ef5404ab5f67fd7344b30877b71426d00bb7b78727ba4d648445f66bc54569fR114)